### PR TITLE
Fix: project timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ export default function PreviewButton(props: PreviewButtonProps) {
   const onClickPreview = async () => {
     try {
       const currentDate = await Forma.sun.getDate();
+      const projectTimezone = await Forma.project.getTimezone();
+      const offsetMs = getTimezoneOffset(currentDate, projectTimezone);
       const year = currentDate.getFullYear();
-      const startDate = new Date(year, month, day, startHour, startMinute, 0, 0);
-      const endDate = new Date(year, month, day, endHour, endMinute, 0, 0);
+      const startDate = new Date(year, month, day, startHour, startMinute, 0, offsetMs);
+      const endDate = new Date(year, month, day, endHour, endMinute, 0, offsetMs);
 
       while (startDate.getTime() <= endDate.getTime()) {
         await Forma.sun.setDate({ date: startDate });
@@ -152,15 +154,22 @@ export default function PreviewButton(props: PreviewButtonProps) {
 }
 ```
 
-The first which happens when the user clicks the _Preview_ button, is that we fetch the currently set date in the Forma scene:
+The first which happens when the user clicks the _Preview_ button, is that we fetch the currently set date in the Forma scene, along with the timezone which the project is located in:
 
 ```ts
 const currentDate = await Forma.sun.getDate();
+const projectTimezone = await Forma.project.getTimezone();
 ```
 
 We want this info in order to reset the scene after the illustration is
-complete. It is worth pointing out that most functionality in the SDK is `async`
-and must be awaited or resolved.
+complete, and to make sure that we offset dates and times correctly.
+It is worth pointing out that most functionality in the SDK is `async` and must
+be awaited or resolved.
+
+You can check out `getTimeZoneOffset()` under `src/utils.ts` if you are curious
+about the offset. Since `Date` objects in JavaScript are based on the instance
+where the script is run, it is important to capture the discrepancy between the
+machine local time and the time at the project location.
 
 We then access the selected start and end times through the `props` which are
 sent into the component. The state of these are handled in the main app as

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "file-saver": "^2.0.5",
-    "forma-embedded-view-sdk": "^0.10.2",
+    "forma-embedded-view-sdk": "^0.12.0",
     "jszip": "3.10.1",
     "lodash": "^4.17.21",
     "preact": "^10.17.1",

--- a/src/components/PreviewButton.tsx
+++ b/src/components/PreviewButton.tsx
@@ -1,5 +1,6 @@
 import { Forma } from "forma-embedded-view-sdk/auto";
 import { SecondaryButton, Row } from "../styles";
+import { getTimezoneOffset } from "../utils";
 
 function timeout(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -20,10 +21,15 @@ export default function PreviewButton(props: PreviewButtonProps) {
 
   const onClickPreview = async () => {
     try {
+      const projectTimezone = await Forma.project.getTimezone();
+      if (!projectTimezone) {
+        throw new Error("Unable to access project timezone");
+      }
       const currentDate = await Forma.sun.getDate();
+      const offsetMs = getTimezoneOffset(currentDate, projectTimezone);
       const year = currentDate.getFullYear();
-      const startDate = new Date(year, month, day, startHour, startMinute, 0, 0);
-      const endDate = new Date(year, month, day, endHour, endMinute, 0, 0);
+      const startDate = new Date(year, month, day, startHour, startMinute, 0, offsetMs);
+      const endDate = new Date(year, month, day, endHour, endMinute, 0, offsetMs);
 
       while (startDate.getTime() <= endDate.getTime()) {
         await Forma.sun.setDate({ date: startDate });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,6 @@ export const MONTHS = [
 ];
 
 export const getTimezoneOffset = (date: Date, timeZone: string) => {
-  const timezoneDate = new Date(date.toLocaleString("en-GB", { timeZone }));
+  const timezoneDate = new Date(date.toLocaleString("en", { timeZone }));
   return date.getTime() - timezoneDate.getTime();
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,8 @@ export const MONTHS = [
   "November",
   "December",
 ];
+
+export const getTimezoneOffset = (date: Date, timeZone: string) => {
+  const timezoneDate = new Date(date.toLocaleString("en-GB", { timeZone }));
+  return date.getTime() - timezoneDate.getTime();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -544,10 +544,10 @@ file-saver@^2.0.5:
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
   integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
-forma-embedded-view-sdk@^0.10.2:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/forma-embedded-view-sdk/-/forma-embedded-view-sdk-0.10.2.tgz#e1029f3cdeb8acf8b643165e33bd375873f4c71f"
-  integrity sha512-B96BfJZRp9tkWa8L1ga4RScMyclgsHoAUQGDTLGNxTXJ+b6b+mSlR892cqBxd2R4m+KrTZadbTvNxacbwmpPFw==
+forma-embedded-view-sdk@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/forma-embedded-view-sdk/-/forma-embedded-view-sdk-0.12.0.tgz#7e3bd89793ce5acba87fa9465be92246212cae7b"
+  integrity sha512-UGGVRlGWv7mQO01BRhRdS1M3fpJCSgIqxWVvkrVYrMNaJNDiGIcQ74rqyQbcq/aWQN3zTPDMSR9mGTIbZefhuQ==
   dependencies:
     uuid "^9.0.0"
 


### PR DESCRIPTION
Extension needs to be aware of project timezone in order to set the correct sun dates. Note that we don't need to go the extra step via UTC since both the date returned from the Forma API and the dates created within the extension have the same local timezone. We just need to know what the difference between the project timezone and that is.

Depends on:
* https://github.com/spacemakerai/forma-extensions/pull/127
* https://github.com/spacemakerai/forma-embedded-view-sdk/pull/51
* https://github.com/spacemakerai/designmode/pull/1253

Have verified that it works for projects in Europe, California and New York with the above PRs wired up locally.

Have also verified that it works after merging the above PRs and just running this extension on 8081 with `local_testing`. 

TODO: 
- [x] bump SDK to 0.12.0 when it is released