### PR TITLE
Avoid windows reserverd characters

### DIFF
--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -54,14 +54,7 @@ export default function ExportButton(props: ExportButtonProps) {
       );
       while (current.toMillis() <= endDate.toMillis()) {
         await Forma.sun.setDate({ date: current.toJSDate() });
-
-        const filename =
-          current.toLocaleString({
-            timeZone: projectTimezone,
-            hour: "2-digit",
-            minute: "2-digit",
-            hour12: false,
-          }) + ".png";
+        const filename = `${current.toFormat("HH-mm")}.png`;
         const canvas = await Forma.camera.capture({ width, height });
         const data = canvas.toDataURL().split("base64,")[1];
         zipFolder.file(filename, data, { base64: true });


### PR DESCRIPTION
The approach with "toLocale" may include `:` or `/` in file names inside the zip file. Windows fails to unzip these files with errors around "The parameter is incorrect".

Instead just format to simle HH-mm regardless of locale.

I've verified this works as it should across timezones, where I still got the appropriate file names on a project in the US, while my machine had CET as timezone.